### PR TITLE
Add data path selection

### DIFF
--- a/PacSafe_dialog_base.ui
+++ b/PacSafe_dialog_base.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>560</width>
-    <height>592</height>
+    <height>689</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>210</y>
+     <y>310</y>
      <width>531</width>
      <height>291</height>
     </rect>
@@ -40,7 +40,7 @@
    <property name="geometry">
     <rect>
      <x>-20</x>
-     <y>540</y>
+     <y>640</y>
      <width>631</width>
      <height>20</height>
     </rect>
@@ -53,7 +53,7 @@
    <property name="geometry">
     <rect>
      <x>50</x>
-     <y>560</y>
+     <y>660</y>
      <width>441</width>
      <height>16</height>
     </rect>
@@ -87,11 +87,11 @@
     <bool>true</bool>
    </property>
   </widget>
-  <widget class="QPushButton" name="btn">
+  <widget class="QPushButton" name="btnProject">
    <property name="geometry">
     <rect>
      <x>350</x>
-     <y>510</y>
+     <y>610</y>
      <width>90</width>
      <height>28</height>
     </rect>
@@ -136,7 +136,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>510</y>
+     <y>610</y>
      <width>141</width>
      <height>28</height>
     </rect>
@@ -158,7 +158,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>150</y>
+     <y>240</y>
      <width>531</width>
      <height>61</height>
     </rect>
@@ -184,7 +184,7 @@
    <property name="geometry">
     <rect>
      <x>450</x>
-     <y>510</y>
+     <y>610</y>
      <width>91</width>
      <height>28</height>
     </rect>
@@ -213,7 +213,7 @@
    <property name="geometry">
     <rect>
      <x>160</x>
-     <y>510</y>
+     <y>610</y>
      <width>71</width>
      <height>28</height>
     </rect>
@@ -238,17 +238,64 @@
     <bool>false</bool>
    </property>
   </widget>
+  <widget class="QGroupBox" name="groupBox_3">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>170</y>
+     <width>531</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Select data folder</string>
+   </property>
+   <widget class="QLineEdit" name="dataPath">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>20</y>
+      <width>361</width>
+      <height>20</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnDataFolder">
+    <property name="geometry">
+     <rect>
+      <x>390</x>
+      <y>20</y>
+      <width>81</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Select folder</string>
+    </property>
+   </widget>
+  </widget>
   <zorder>groupBox_2</zorder>
   <zorder>groupBox</zorder>
   <zorder>line</zorder>
   <zorder>label_2</zorder>
   <zorder>label_3</zorder>
-  <zorder>btn</zorder>
-  <zorder>label</zorder>
+  <zorder>btnProject</zorder>
   <zorder>btnRemote</zorder>
   <zorder>btnClose</zorder>
   <zorder>btnHelp</zorder>
+  <zorder>groupBox_3</zorder>
+  <zorder>label</zorder>
  </widget>
+ <tabstops>
+  <tabstop>btnDataFolder</tabstop>
+  <tabstop>dataPath</tabstop>
+  <tabstop>countryListWidget</tabstop>
+  <tabstop>listWidget</tabstop>
+  <tabstop>btnHelp</tabstop>
+  <tabstop>btnRemote</tabstop>
+  <tabstop>btnProject</tabstop>
+  <tabstop>btnClose</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This update adds a new dialog to allow users to select the folder that contains the country-specific data folders, rather than assuming the folders exist in a subdirectory of the current working path. Users click
on the 'Select folder' button and choose the path to a folder that contains subdirectories for each country (currently only Fiji and Tonga). The dialog automatically updates the list of available projects for that country, based on the QGIS project files in the subdirectory. If the selected folder does not contain the expected directory structure, a message box is displayed, telling the user to select a directory where
the country projects are stored.

TODO: Icons and logos are not appearing in the completed GUI